### PR TITLE
Bump eslint versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,9 +28,18 @@ module.exports = {
     'no-underscore-dangle': 'off',
     'one-var': 'off',
     'prefer-template': 'off',
-    'space-before-function-paren': ['error', 'never'],
+    'space-before-function-paren': ['error', {
+      anonymous: 'never',
+      named: 'never',
+      asyncArrow: 'always'
+    }],
     strict: 'off',
     'import/no-dynamic-require': 'off',
-    'no-cond-assign': ['error', 'except-parens']
+    'no-cond-assign': ['error', 'except-parens'],
+    indent: ['error', 2, {
+      MemberExpression: 'off',
+      SwitchCase: 1
+    }],
+    'no-multi-spaces': ['error', { ignoreEOLComments: true }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   "author": "Stefano Sala <stefano@conversio.com>",
   "license": "MIT",
   "peerDependencies": {
-    "eslint": "^3.9.1"
+    "eslint": "^4.16.0"
   },
   "dependencies": {
-    "eslint-config-airbnb-base": "^10.0.1",
-    "eslint-plugin-import": "^2.1.0"
+    "eslint-config-airbnb-base": "^12.1.0",
+    "eslint-plugin-import": "^2.8.0"
   },
   "devDependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,9 +44,11 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-eslint-config-airbnb-base@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-10.0.1.tgz#f17d4e52992c1d45d1b7713efbcd5ecd0e7e0506"
+eslint-config-airbnb-base@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz#386441e54a12ccd957b0a92564a4bafebd747944"
+  dependencies:
+    eslint-restricted-globals "^0.1.1"
 
 eslint-import-resolver-node@^0.3.1:
   version "0.3.1"
@@ -62,9 +64,9 @@ eslint-module-utils@^2.1.1:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
-eslint-plugin-import@^2.1.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz#21de33380b9efb55f5ef6d2e210ec0e07e7fa69f"
+eslint-plugin-import@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz#fa1b6ef31fcb3c501c09859c1b86f1fc5b986894"
   dependencies:
     builtin-modules "^1.1.1"
     contains-path "^0.1.0"
@@ -76,6 +78,10 @@ eslint-plugin-import@^2.1.0:
     lodash.cond "^4.3.0"
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
+
+eslint-restricted-globals@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
 
 esutils@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
First custom rule is because `async () => {}` is now an error vs `async() => {}`
Second custom rule is because these are errors:

```javascript
Function([
])
.call()

switch (val) {
  case 'val':
    break;
}
```

Last rule is because this is an error:
```javascript
const obj = {
  things: 12, // this does X
  hm: 3       // this is aligned for readability
}
```
