### PR TITLE
Fix rule import, missing extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: [
     'airbnb-base',
-    './rules/react'
+    './rules/react.js'
   ],
   env: {
     node: true,


### PR DESCRIPTION
For some reasons I'm getting this error:
```
$ eslint --ext .js --ext .jsx client server
Error: Cannot read config file: /app/user/node_modules/eslint-config-conversio/rules/react
Error: ENOENT: no such file or directory, open '/app/user/node_modules/eslint-config-conversio/rules/react'
Referenced from: /app/user/node_modules/eslint-config-conversio/index.js
Referenced from: /app/user/.eslintrc.json
    at Object.openSync (fs.js:436:3)
    at Object.readFileSync (fs.js:341:35)
    at readFile (/app/user/node_modules/eslint/lib/config/config-file.js:64:15)
    at loadLegacyConfigFile (/app/user/node_modules/eslint/lib/config/config-file.js:141:44)
    at loadConfigFile (/app/user/node_modules/eslint/lib/config/config-file.js:240:22)
    at loadFromDisk (/app/user/node_modules/eslint/lib/config/config-file.js:500:18)
    at load (/app/user/node_modules/eslint/lib/config/config-file.js:564:20)
    at configExtends.reduceRight (/app/user/node_modules/eslint/lib/config/config-file.js:430:36)
    at Array.reduceRight (<anonymous>)
    at applyExtends (/app/user/node_modules/eslint/lib/config/config-file.js:408:26)
```